### PR TITLE
added copick utils via uv

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,8 @@ dependencies = [
     "uvicorn",
     "zarr",
     "fsspec",
-    "starlette"
+    "starlette",
+    "copick-utils",
 ]
 
 [build-system]
@@ -20,3 +21,6 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["copick_server"]
+
+[tool.uv.sources]
+copick-utils = { git = "https://github.com/copick/copick-utils" }


### PR DESCRIPTION
I'm not sure if you're okay with the `uv` metadata in the pyproject.toml. I think it would also be supported directly via the `git+...` syntax in the requirements, but in any case, this is what I did to fix #2 