### PR TITLE
Refactor from Starlette to FastAPI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,57 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install ".[test]"
+          
+      - name: Run tests
+        run: |
+          pytest
+          
+      - name: Upload coverage report
+        uses: codecov/codecov-action@v3
+        with:
+          file: ./coverage.xml
+          fail_ci_if_error: false
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+          
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install black ruff
+          
+      - name: Run linters
+        run: |
+          black --check copick_server tests
+          ruff check copick_server tests

--- a/README.md
+++ b/README.md
@@ -10,6 +10,18 @@ uv run copick_server/demo_server.py
 uv run copick_server/client.py
 ```
 
+# Running Tests
+
+```
+pip install ".[test]"
+pytest
+```
+
+For coverage report:
+```
+pytest --cov=copick_server
+```
+
 # References
 
 The idea is influenced by https://github.com/manzt/simple-zarr-server, but aimed at supporting https://github.com/copick/copick.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,14 @@ dependencies = [
     "copick-utils",
 ]
 
+[project.optional-dependencies]
+test = [
+    "pytest",
+    "pytest-asyncio",
+    "httpx",
+    "pytest-cov",
+]
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "uvicorn",
     "zarr",
     "fsspec",
-    "starlette",
+    "fastapi",
     "copick-utils",
 ]
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,9 @@
+[pytest]
+testpaths = tests
+python_files = test_*.py
+python_classes = Test*
+python_functions = test_*
+asyncio_mode = auto
+
+# Coverage settings
+addopts = --cov=copick_server --cov-report=term --cov-report=xml --cov-report=html

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,71 @@
+import json
+import os
+import tempfile
+from pathlib import Path
+
+import copick
+import pytest
+from fastapi.testclient import TestClient
+
+from copick_server.server import create_copick_app
+
+
+@pytest.fixture
+def example_config():
+    """Create a temporary example Copick configuration."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # Create the overlay directory structure
+        overlay_path = Path(temp_dir) / "overlay"
+        overlay_path.mkdir()
+        
+        # Create a simple Copick config
+        config_data = {
+            "name": "Test Project",
+            "description": "Test project for unit tests",
+            "version": "0.5.0",
+            "pickable_objects": [
+                {
+                    "name": "test_object",
+                    "is_particle": True,
+                    "label": 1,
+                    "color": [0, 117, 220, 255],
+                    "radius": 150.0
+                }
+            ],
+            "user_id": "test_user",
+            "config_type": "cryoet_data_portal",
+            "overlay_root": f"local://{str(overlay_path)}/",
+            "dataset_ids": [12345],
+            "overlay_fs_args": {
+                "auto_mkdir": True
+            }
+        }
+        
+        # Write config to a temporary file
+        config_path = Path(temp_dir) / "test_config.json"
+        with open(config_path, "w") as f:
+            json.dump(config_data, f)
+            
+        yield str(config_path)
+
+
+@pytest.fixture
+def mock_copick_root(monkeypatch, example_config):
+    """Mock a CopickRoot instance for testing."""
+    # Create a minimal mock root with just enough functionality for testing
+    # In a real setup, you would mock specific methods of CopickRoot
+    
+    # This is a simple case - for more complex mocking, consider using unittest.mock
+    return copick.from_file(example_config)
+
+
+@pytest.fixture
+def app(mock_copick_root):
+    """Create a test FastAPI application."""
+    return create_copick_app(mock_copick_root, cors_origins=["*"])
+
+
+@pytest.fixture
+def client(app):
+    """Create a test client for the application."""
+    return TestClient(app)

--- a/tests/test_route_handlers.py
+++ b/tests/test_route_handlers.py
@@ -1,0 +1,249 @@
+import json
+import pytest
+import numpy as np
+from unittest.mock import MagicMock, patch, AsyncMock
+
+
+@pytest.mark.asyncio
+async def test_handle_tomogram_invalid_path():
+    """Test handling of an invalid tomogram path."""
+    from copick_server.server import CopickRoute
+    
+    # Create mocks
+    run_mock = MagicMock()
+    request_mock = MagicMock()
+    route_handler = CopickRoute(MagicMock())
+    
+    # Test with too short path
+    response = await route_handler._handle_tomogram(request_mock, run_mock, "invalid")
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_handle_tomogram_invalid_voxel_spacing():
+    """Test handling of an invalid voxel spacing in tomogram path."""
+    from copick_server.server import CopickRoute
+    
+    # Create mocks
+    run_mock = MagicMock()
+    request_mock = MagicMock()
+    route_handler = CopickRoute(MagicMock())
+    
+    # Test with invalid voxel spacing
+    response = await route_handler._handle_tomogram(request_mock, run_mock, "VoxelSpacingXYZ/test.zarr")
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_handle_tomogram_unknown_voxel_spacing():
+    """Test handling of an unknown voxel spacing."""
+    from copick_server.server import CopickRoute
+    
+    # Create mocks
+    run_mock = MagicMock()
+    run_mock.get_voxel_spacing.return_value = None
+    request_mock = MagicMock()
+    route_handler = CopickRoute(MagicMock())
+    
+    # Test with unknown voxel spacing
+    response = await route_handler._handle_tomogram(request_mock, run_mock, "VoxelSpacing10.0/test.zarr")
+    assert response.status_code == 404
+    run_mock.get_voxel_spacing.assert_called_once_with(10.0)
+
+
+@pytest.mark.asyncio
+async def test_handle_tomogram_unknown_tomogram():
+    """Test handling of an unknown tomogram type."""
+    from copick_server.server import CopickRoute
+    
+    # Create mocks
+    vs_mock = MagicMock()
+    vs_mock.get_tomogram.return_value = None
+    run_mock = MagicMock()
+    run_mock.get_voxel_spacing.return_value = vs_mock
+    request_mock = MagicMock()
+    route_handler = CopickRoute(MagicMock())
+    
+    # Test with unknown tomogram
+    response = await route_handler._handle_tomogram(request_mock, run_mock, "VoxelSpacing10.0/test.zarr")
+    assert response.status_code == 404
+    vs_mock.get_tomogram.assert_called_once_with("test")
+
+
+@pytest.mark.asyncio
+async def test_handle_tomogram_put_readonly():
+    """Test handling of PUT request to readonly tomogram."""
+    from copick_server.server import CopickRoute
+    
+    # Create mocks
+    tomogram_mock = MagicMock()
+    tomogram_mock.read_only = True
+    vs_mock = MagicMock()
+    vs_mock.get_tomogram.return_value = tomogram_mock
+    run_mock = MagicMock()
+    run_mock.get_voxel_spacing.return_value = vs_mock
+    request_mock = MagicMock()
+    request_mock.method = "PUT"
+    route_handler = CopickRoute(MagicMock())
+    
+    # Test PUT to readonly tomogram
+    body_mock = AsyncMock()
+    request_mock.body = body_mock
+    
+    # Mock the zarr method to return a dict-like object
+    zarr_mock = MagicMock()
+    zarr_mock.__getitem__.return_value = b"test_data"
+    tomogram_mock.zarr.return_value = zarr_mock
+    
+    response = await route_handler._handle_tomogram(request_mock, run_mock, "VoxelSpacing10.0/test.zarr/0")
+    assert response.status_code == 200
+    
+    # Since it's readonly, zarr.__getitem__ should be called, not zarr.__setitem__
+    zarr_mock.__getitem__.assert_called_once_with("0")
+    zarr_mock.__setitem__.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_handle_picks_invalid_path():
+    """Test handling of an invalid picks path."""
+    from copick_server.server import CopickRoute
+    
+    # Create mocks
+    run_mock = MagicMock()
+    request_mock = MagicMock()
+    route_handler = CopickRoute(MagicMock())
+    
+    # Test with empty path
+    response = await route_handler._handle_picks(request_mock, run_mock, "")
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_handle_picks_invalid_format():
+    """Test handling of picks with invalid filename format."""
+    from copick_server.server import CopickRoute
+    
+    # Create mocks
+    run_mock = MagicMock()
+    request_mock = MagicMock()
+    route_handler = CopickRoute(MagicMock())
+    
+    # Test with invalid format (should have 3 parts: user_session_object.json)
+    response = await route_handler._handle_picks(request_mock, run_mock, "invalid_format.json")
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_handle_picks_get_not_found():
+    """Test handling of GET request for non-existent picks."""
+    from copick_server.server import CopickRoute
+    
+    # Create mocks
+    run_mock = MagicMock()
+    run_mock.get_picks.return_value = []  # No picks found
+    request_mock = MagicMock()
+    request_mock.method = "GET"
+    route_handler = CopickRoute(MagicMock())
+    
+    # Test GET for non-existent picks
+    response = await route_handler._handle_picks(request_mock, run_mock, "user_session_object.json")
+    assert response.status_code == 404
+    run_mock.get_picks.assert_called_once_with(
+        object_name="object", user_id="user", session_id="session"
+    )
+
+
+@pytest.mark.asyncio
+async def test_handle_segmentation_invalid_path():
+    """Test handling of an invalid segmentation path."""
+    from copick_server.server import CopickRoute
+    
+    # Create mocks
+    run_mock = MagicMock()
+    request_mock = MagicMock()
+    route_handler = CopickRoute(MagicMock())
+    
+    # Test with empty path
+    response = await route_handler._handle_segmentation(request_mock, run_mock, "")
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_handle_segmentation_invalid_format():
+    """Test handling of segmentation with invalid filename format."""
+    from copick_server.server import CopickRoute
+    
+    # Create mocks
+    run_mock = MagicMock()
+    request_mock = MagicMock()
+    route_handler = CopickRoute(MagicMock())
+    
+    # Test with invalid format (should have at least 4 parts: voxel_user_session_name.zarr)
+    response = await route_handler._handle_segmentation(request_mock, run_mock, "invalid_format.zarr")
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+@patch("copick_utils.writers.write.segmentation")
+async def test_handle_segmentation_put(mock_write_segmentation):
+    """Test handling of PUT request for a segmentation."""
+    from copick_server.server import CopickRoute
+    
+    # Create mocks
+    run_mock = MagicMock()
+    request_mock = MagicMock()
+    request_mock.method = "PUT"
+    route_handler = CopickRoute(MagicMock())
+    
+    # Mock the request body to return a byte array with shape info and data
+    # (24 bytes for shape + data)
+    shape = np.array([10, 10, 10], dtype=np.int64)
+    data = np.zeros((10, 10, 10), dtype=np.uint8)
+    body = shape.tobytes() + data.tobytes()
+    
+    body_mock = AsyncMock()
+    body_mock.return_value = body
+    request_mock.body = body_mock
+    
+    # Test PUT for segmentation
+    response = await route_handler._handle_segmentation(request_mock, run_mock, "10.0_user_session_object.zarr")
+    
+    assert response.status_code == 200
+    mock_write_segmentation.assert_called_once()
+    
+    # Check that the parameters are correct
+    args, kwargs = mock_write_segmentation.call_args
+    assert kwargs["run"] == run_mock
+    assert kwargs["user_id"] == "user"
+    assert kwargs["session_id"] == "session"
+    assert kwargs["name"] == "object"
+    assert kwargs["voxel_size"] == 10.0
+    assert kwargs["multilabel"] == False
+    
+    # Check that the segmentation volume shape is correct
+    assert kwargs["segmentation_volume"].shape == (10, 10, 10)
+
+
+@pytest.mark.asyncio
+async def test_handle_segmentation_get_not_found():
+    """Test handling of GET request for non-existent segmentation."""
+    from copick_server.server import CopickRoute
+    
+    # Create mocks
+    run_mock = MagicMock()
+    run_mock.get_segmentations.return_value = []  # No segmentations found
+    request_mock = MagicMock()
+    request_mock.method = "GET"
+    route_handler = CopickRoute(MagicMock())
+    
+    # Test GET for non-existent segmentation
+    response = await route_handler._handle_segmentation(request_mock, run_mock, "10.0_user_session_object.zarr")
+    
+    assert response.status_code == 404
+    run_mock.get_segmentations.assert_called_once_with(
+        voxel_size=10.0,
+        name="object",
+        user_id="user",
+        session_id="session",
+        is_multilabel=False
+    )

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,118 @@
+import json
+import pytest
+from unittest.mock import MagicMock, patch
+
+
+def test_create_copick_app(app):
+    """Test that the app is created correctly."""
+    assert app is not None
+    assert app.routes is not None
+    # Check that our catch-all route exists
+    assert any(route.path == "/{path:path}" for route in app.routes)
+
+
+def test_cors_middleware(mock_copick_root):
+    """Test that CORS middleware is added correctly."""
+    from copick_server.server import create_copick_app
+    
+    # Create app with CORS origins
+    app = create_copick_app(mock_copick_root, cors_origins=["https://example.com"])
+    
+    # Check that the middleware exists
+    assert len(app.user_middleware) > 0
+    middleware_classes = [m.__class__.__name__ for m in app.user_middleware]
+    assert "CORSMiddleware" in middleware_classes
+
+
+@pytest.mark.asyncio
+async def test_handle_request_invalid_path(client):
+    """Test handling of an invalid path."""
+    response = client.get("/invalid/path")
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+@patch("copick_server.server.CopickRoute._handle_tomogram")
+async def test_handle_tomogram_request(mock_handle_tomogram, client, monkeypatch):
+    """Test that tomogram requests are routed correctly."""
+    # Mock the get_run method to return a valid run
+    run_mock = MagicMock()
+    root_mock = MagicMock()
+    root_mock.get_run.return_value = run_mock
+    
+    # Patch to replace the route handler's root with our mock
+    with patch("copick_server.server.CopickRoute.root", root_mock):
+        # Set up mock for _handle_tomogram
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_handle_tomogram.return_value = mock_response
+        
+        # Make the request
+        response = client.get("/test_run/Tomograms/VoxelSpacing10.0/test.zarr")
+        
+        # Verify the response
+        assert response.status_code == 200
+        
+        # Verify the correct run was obtained
+        root_mock.get_run.assert_called_once_with("test_run")
+        
+        # Verify _handle_tomogram was called
+        mock_handle_tomogram.assert_called_once()
+
+
+@pytest.mark.asyncio
+@patch("copick_server.server.CopickRoute._handle_picks")
+async def test_handle_picks_request(mock_handle_picks, client, monkeypatch):
+    """Test that picks requests are routed correctly."""
+    # Mock the get_run method to return a valid run
+    run_mock = MagicMock()
+    root_mock = MagicMock()
+    root_mock.get_run.return_value = run_mock
+    
+    # Patch to replace the route handler's root with our mock
+    with patch("copick_server.server.CopickRoute.root", root_mock):
+        # Set up mock for _handle_picks
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_handle_picks.return_value = mock_response
+        
+        # Make the request
+        response = client.get("/test_run/Picks/user_session_test.json")
+        
+        # Verify the response
+        assert response.status_code == 200
+        
+        # Verify the correct run was obtained
+        root_mock.get_run.assert_called_once_with("test_run")
+        
+        # Verify _handle_picks was called
+        mock_handle_picks.assert_called_once()
+
+
+@pytest.mark.asyncio
+@patch("copick_server.server.CopickRoute._handle_segmentation")
+async def test_handle_segmentation_request(mock_handle_segmentation, client, monkeypatch):
+    """Test that segmentation requests are routed correctly."""
+    # Mock the get_run method to return a valid run
+    run_mock = MagicMock()
+    root_mock = MagicMock()
+    root_mock.get_run.return_value = run_mock
+    
+    # Patch to replace the route handler's root with our mock
+    with patch("copick_server.server.CopickRoute.root", root_mock):
+        # Set up mock for _handle_segmentation
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_handle_segmentation.return_value = mock_response
+        
+        # Make the request
+        response = client.get("/test_run/Segmentations/10.0_user_session_test.zarr")
+        
+        # Verify the response
+        assert response.status_code == 200
+        
+        # Verify the correct run was obtained
+        root_mock.get_run.assert_called_once_with("test_run")
+        
+        # Verify _handle_segmentation was called
+        mock_handle_segmentation.assert_called_once()


### PR DESCRIPTION
This PR refactors the server implementation from Starlette to FastAPI while maintaining all existing functionality.

## Changes
- Updated dependency in `pyproject.toml` from `starlette` to `fastapi`
- Refactored `server.py` to use FastAPI instead of Starlette
- Made minimal changes to preserve all existing functionality and endpoint behavior
- Maintained the same API interface for consumers

This refactoring provides several benefits:
1. FastAPI offers automatic API documentation via Swagger UI and ReDoc
2. Built-in request validation via Pydantic if needed in the future
3. Better type hints and editor support
4. All existing code and clients should continue to work without any changes

The refactoring was kept intentionally minimal to ensure compatibility with existing code and avoid introducing bugs or changing behavior.